### PR TITLE
In arguments, allow values to have `=` chars.

### DIFF
--- a/renderer/parameters/parameters.go
+++ b/renderer/parameters/parameters.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	// VarArgRegexp defines the extra variable parameter format
-	VarArgRegexp = matcher.Must(`^(?P<name>\S+)=(?P<value>[\S ]*)$`)
+	VarArgRegexp = matcher.Must(`^(?P<name>[^ \t\r\n\f=]+)=(?P<value>[\S ]*)$`)
 )
 
 // Parameters is a map used to render the templates with

--- a/renderer/parameters/parameters_test.go
+++ b/renderer/parameters/parameters_test.go
@@ -388,3 +388,11 @@ func MatchesPatternWithValueHavingEqualSign(t *testing.T) {
  assert.Equal(t, "key", groups["name"])
  assert.Equal(t, "value=with=equals", groups["value"])
 }
+
+func TestVarArgRegexp(t *testing.T) {
+  t.Run("MatchesValidPattern", MatchesValidPattern)
+  t.Run("MatchesPatternWithSpaces", MatchesPatternWithSpaces)
+  t.Run("DoesNotMatchInvalidPattern", DoesNotMatchInvalidPattern)
+  t.Run("DoesNotMatchEmptyString", DoesNotMatchEmptyString)
+  t.Run("MatchesPatternWithValueHavingEqualSign", MatchesPatternWithValueHavingEqualSign)
+}

--- a/renderer/parameters/parameters_test.go
+++ b/renderer/parameters/parameters_test.go
@@ -347,3 +347,44 @@ func TestAppendNested(t *testing.T) {
 		t.Run(fmt.Sprintf("[%d] %s", i, tt.name), func(t *testing.T) { tt.f(tt) })
 	}
 }
+
+func MatchesValidPattern(t *testing.T) {
+	input := "key=value"
+	groups, ok := VarArgRegexp.MatchGroups(input)
+
+	assert.True(t, ok)
+	assert.Equal(t, "key", groups["name"])
+	assert.Equal(t, "value", groups["value"])
+}
+
+func MatchesPatternWithSpaces(t *testing.T) {
+	input := "key=value with spaces"
+	groups, ok := VarArgRegexp.MatchGroups(input)
+
+	assert.True(t, ok)
+	assert.Equal(t, "key", groups["name"])
+	assert.Equal(t, "value with spaces", groups["value"])
+}
+
+func DoesNotMatchInvalidPattern(t *testing.T) {
+	input := "keyvalue"
+	_, ok := VarArgRegexp.MatchGroups(input)
+
+	assert.False(t, ok)
+}
+
+func DoesNotMatchEmptyString(t *testing.T) {
+	input := ""
+	_, ok := VarArgRegexp.MatchGroups(input)
+
+	assert.False(t, ok)
+}
+
+func MatchesPatternWithValueHavingEqualSign(t *testing.T) {
+ input := "key=value=with=equals"
+ groups, ok := VarArgRegexp.MatchGroups(input)
+
+ assert.True(t, ok)
+ assert.Equal(t, "key", groups["name"])
+ assert.Equal(t, "value=with=equals", groups["value"])
+}


### PR DESCRIPTION
In arguments, allow values to have `=` chars.